### PR TITLE
Dockerfile for portable use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM nixos/nix
+
+RUN nix-env -i git \
+  && git clone https://github.com/Shopify/comma.git \
+  && nix-env -e git \
+  && cd comma \
+  && nix-env -i -f .
+
+ENTRYPOINT [ "," ]


### PR DESCRIPTION
I found myself using this with a Dockerfile to avoid modifying my filesystem on OSx (Catalina and Big Sur require mounted filesystems on the `/nix` path of the filesystem).  I thought perhaps it could be useful here as well.

Definitely feel free to edit or make suggestions or close if this isn't useful. I could understand wanting documentation around this or a hosted Docker image to pull.

The way I use this is as follows:

* Build the container (could be pulled if hosted on a registry)
```sh
docker build --pull --rm -f "Dockerfile" -t Shopify/comma:latest
```
* Update `".${SHELL}rc"` to wrap the `docker run` command in an alias
```sh
alias ,='docker run -it shopify/comma'
```
* Run executable as desired
```sh
, cowsay "Hello from Docker!"
```